### PR TITLE
Fix stack bad axis for older NumPy

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -183,11 +183,16 @@ class TestJoin(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, a), axis=2)
 
-    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_stack_with_axis_over(self, xp):
         a = testing.shaped_arange((2, 3), xp)
-        return xp.stack((a, a), axis=3)
+        try:
+            return xp.stack((a, a), axis=3)
+        except IndexError as e:
+            # For 'numpy<=1.12', catch both IndexError from NumPy and
+            # IndexOrValueError from CuPy. For 'numpy>=1.13', simply do not
+            # catch the AxisError.
+            raise IndexError()
 
     def test_stack_with_axis_value(self):
         a = testing.shaped_arange((2, 3), cupy)


### PR DESCRIPTION
Test all NumPy versions for bad stack axis argument.